### PR TITLE
Add connect_timeout option for pg_connect

### DIFF
--- a/psql
+++ b/psql
@@ -11,15 +11,17 @@ $opts = getopt('h', [
     'username:',
     'password:',
     'database:',
+    'connect_timeout:',
 ]);
 if (array_key_exists('h', $opts)) {
     fwrite(\STDOUT, implode(\PHP_EOL, [
         'Usage: psql [OPTIONS]',
-        '  --host       Connect to host',
-        '  --port       Port number',
-        '  --username   User for login',
-        '  --password   Password to use',
-        '  --database   Database to use',
+        '  --host              Connect to host',
+        '  --port              Port number',
+        '  --username          User for login',
+        '  --password          Password to use',
+        '  --database          Database to use',
+        '  --connect_timeout   Connect timeout to use',
         '',
     ]));
 
@@ -32,6 +34,7 @@ $psql = new \SlamPsql\Psql(
     $opts['username'],
     $opts['password'],
     $opts['database'] ?? null,
+    $opts['connect_timeout'] ?? null,
 );
 $return = $psql->run(\STDIN, \STDOUT, \STDERR);
 

--- a/src/Psql.php
+++ b/src/Psql.php
@@ -14,6 +14,7 @@ final class Psql implements PsqlInterface
         private readonly string $username,
         private readonly string $password,
         private readonly ?string $database,
+        private readonly ?int $connectTimeout,
     ) {}
 
     /**
@@ -51,6 +52,9 @@ final class Psql implements PsqlInterface
         );
         if (null !== $this->database) {
             $pgConnectionParams .= ' dbname='.$this->database;
+        }
+        if (null !== $this->connectTimeout) {
+            $pgConnectionParams .= sprintf(' connect_timeout=%s', $this->connectTimeout);
         }
 
         set_error_handler(static function ($severity, $message, $file, $line): void {

--- a/tests/PsqlTest.php
+++ b/tests/PsqlTest.php
@@ -24,6 +24,7 @@ final class PsqlTest extends TestCase
             'postgres',
             'root_password',
             'postgres',
+            5,
         );
     }
 
@@ -35,6 +36,7 @@ final class PsqlTest extends TestCase
             5432,
             $user,
             uniqid(),
+            null,
             null,
         );
 


### PR DESCRIPTION
# Changed log

- Add the `connect_timeout` argument support because I think it needs to set the connection timeout argument when connecting the PostgreSQL database server.
- Maybe setting the default connection timeout when the `connect_timeout` argument is not specified.